### PR TITLE
Hw/feature/player polishing

### DIFF
--- a/Assets/Animator/PlayerMotion.controller
+++ b/Assets/Animator/PlayerMotion.controller
@@ -32,7 +32,7 @@ BlendTree:
     m_CycleOffset: 0
     m_DirectBlendParameter: Melee
     m_Mirror: 0
-  m_BlendParameter: Melee
+  m_BlendParameter: Combo
   m_BlendParameterY: Blend
   m_MinThreshold: 0
   m_MaxThreshold: 1
@@ -63,7 +63,7 @@ AnimatorState:
   m_TimeParameterActive: 0
   m_Motion: {fileID: 2607316450448073625, guid: 49066920dfe8e144797608de67d7c8d0, type: 3}
   m_Tag: 
-  m_SpeedParameter: Melee
+  m_SpeedParameter: Combo
   m_MirrorParameter: 
   m_CycleOffsetParameter: 
   m_TimeParameter: 
@@ -170,7 +170,7 @@ AnimatorStateTransition:
   m_Name: 
   m_Conditions:
   - m_ConditionMode: 1
-    m_ConditionEvent: NormalAttack
+    m_ConditionEvent: IsAttacking
     m_EventTreshold: 0
   - m_ConditionMode: 1
     m_ConditionEvent: AttackTrigger
@@ -237,7 +237,7 @@ AnimatorStateMachine:
     m_Position: {x: 440, y: 480, z: 0}
   - serializedVersion: 1
     m_State: {fileID: 7725854424292357697}
-    m_Position: {x: 440, y: 60, z: 0}
+    m_Position: {x: 470, y: 50, z: 0}
   - serializedVersion: 1
     m_State: {fileID: 7944193198401892940}
     m_Position: {x: 470, y: 140, z: 0}
@@ -274,13 +274,13 @@ AnimatorController:
     m_DefaultInt: 0
     m_DefaultBool: 0
     m_Controller: {fileID: 0}
-  - m_Name: Melee
+  - m_Name: Combo
     m_Type: 1
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
     m_Controller: {fileID: 0}
-  - m_Name: Ranged
+  - m_Name: Charging
     m_Type: 1
     m_DefaultFloat: 0
     m_DefaultInt: 0
@@ -292,7 +292,7 @@ AnimatorController:
     m_DefaultInt: 0
     m_DefaultBool: 0
     m_Controller: {fileID: 0}
-  - m_Name: NormalAttack
+  - m_Name: IsAttacking
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
@@ -410,7 +410,7 @@ BlendTree:
     m_CycleOffset: 0
     m_DirectBlendParameter: Melee
     m_Mirror: 0
-  m_BlendParameter: Ranged
+  m_BlendParameter: Charging
   m_BlendParameterY: Blend
   m_MinThreshold: 0
   m_MaxThreshold: 1
@@ -530,7 +530,7 @@ AnimatorStateTransition:
   m_Name: 
   m_Conditions:
   - m_ConditionMode: 2
-    m_ConditionEvent: NormalAttack
+    m_ConditionEvent: IsAttacking
     m_EventTreshold: 0
   m_DstStateMachine: {fileID: 0}
   m_DstState: {fileID: 927208069949211077}

--- a/Assets/Graphics/023D/02animation/01maincharacter/F_02_02_01_move.fbx.meta
+++ b/Assets/Graphics/023D/02animation/01maincharacter/F_02_02_01_move.fbx.meta
@@ -37,7 +37,7 @@ ModelImporter:
       takeName: F_02_02_01_move
       internalID: 2607316450448073625
       firstFrame: 0
-      lastFrame: 16
+      lastFrame: 24
       wrapMode: 2
       orientationOffsetY: 0
       level: 0

--- a/Assets/Scenes/TestScenes/Test_HW/PlayerTest.unity
+++ b/Assets/Scenes/TestScenes/Test_HW/PlayerTest.unity
@@ -6285,6 +6285,11 @@ BoxCollider:
   serializedVersion: 2
   m_Size: {x: 17.25, y: 3.1814623, z: 0.6}
   m_Center: {x: -0.000015258789, y: 0.0000011920929, z: -0.00000071525574}
+--- !u!1 &1344649792 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 9199333450892302302, guid: 62e30b16aefe65f4a9ee39e4732b078f, type: 3}
+  m_PrefabInstance: {fileID: 1146935686}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1349363172 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 919132149155446097, guid: 7b059b14a0cd06844ba042adda41bd56, type: 3}
@@ -8340,7 +8345,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d87b24a34868ed249b68cfdf356739d3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _target: {fileID: 0}
+  _target: {fileID: 1146935687}
   _offset: {x: 0, y: 2, z: 0}
   isVibrate: 0
   vibrationPower: 0
@@ -8484,7 +8489,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 86c6556701af9e04380698b89f691b6e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  attenuationObject: {fileID: 0}
+  attenuationObject: {fileID: 1344649792}
 --- !u!1001 &1707870911
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Objects/Player/PlayerState/PlayerAttackDelayState.cs
+++ b/Assets/Scripts/Objects/Player/PlayerState/PlayerAttackDelayState.cs
@@ -4,6 +4,7 @@ using static PlayerController;
 [FSMState((int)PlayerState.AttackDelay)]
 public class PlayerAttackDelayState : UnitState<PlayerController>
 {
+	private readonly string IsAtttackingAnimKey = "IsAttacking";
 	private float currentTime;
 	protected AttackNode attackNode;
 
@@ -18,12 +19,12 @@ public class PlayerAttackDelayState : UnitState<PlayerController>
 
 	public override void End(PlayerController unit)
 	{
-		
+		unit.animator.SetBool(IsAtttackingAnimKey, false);
 	}
 
 	public override void FixedUpdate(PlayerController unit)
 	{
-		throw new System.NotImplementedException();
+
 	}
 
 	public override void OnTriggerEnter(PlayerController unit, Collider other)
@@ -43,6 +44,6 @@ public class PlayerAttackDelayState : UnitState<PlayerController>
 
 	public override void OnCollisionEnter(PlayerController unit, Collision collision)
 	{
-		throw new System.NotImplementedException();
+
 	}
 }

--- a/Assets/Scripts/Objects/Player/PlayerState/PlayerAttackState.cs
+++ b/Assets/Scripts/Objects/Player/PlayerState/PlayerAttackState.cs
@@ -9,7 +9,7 @@ public class PlayerAttackState : UnitState<PlayerController>
 	// Animation Key
 	protected readonly string IsAttackingAnimKey = "IsAttacking";
 	protected readonly string AttackTriggerAnimKey = "AttackTrigger";
-	protected readonly string MeleeAnimaKey = "Melee";
+	protected readonly string AttackTypeAnimaKey = "Combo";
 
 	// 임시 변수
 	public float animRatio = 0.7f;
@@ -27,7 +27,7 @@ public class PlayerAttackState : UnitState<PlayerController>
 
 		pc.animator.SetBool(IsAttackingAnimKey, true);
 		pc.animator.SetTrigger(AttackTriggerAnimKey);
-		pc.animator.SetFloat(MeleeAnimaKey, pc.curNode.animFloat);
+		pc.animator.SetFloat(AttackTypeAnimaKey, pc.curNode.animFloat);
 		pc.curNode.Copy(pc.curNode);
 		attackNode = pc.curNode;
 		//effect = attackNode.effectPoolManager.ActiveObject(attackNode.effectPos.position, pc.transform.rotation);

--- a/Assets/Scripts/Objects/Player/PlayerState/PlayerAttackState.cs
+++ b/Assets/Scripts/Objects/Player/PlayerState/PlayerAttackState.cs
@@ -7,7 +7,7 @@ using static PlayerController;
 public class PlayerAttackState : UnitState<PlayerController>
 {
 	// Animation Key
-	protected readonly string NormalAttackAnimKey = "NormalAttack";
+	protected readonly string IsAttackingAnimKey = "IsAttacking";
 	protected readonly string AttackTriggerAnimKey = "AttackTrigger";
 	protected readonly string MeleeAnimaKey = "Melee";
 
@@ -25,7 +25,7 @@ public class PlayerAttackState : UnitState<PlayerController>
 		/*if(cam == null)	
 			cam = Camera.main.GetComponent<CameraController>();*/
 
-		pc.animator.SetBool(NormalAttackAnimKey, true);
+		pc.animator.SetBool(IsAttackingAnimKey, true);
 		pc.animator.SetTrigger(AttackTriggerAnimKey);
 		pc.animator.SetFloat(MeleeAnimaKey, pc.curNode.animFloat);
 		pc.curNode.Copy(pc.curNode);
@@ -58,7 +58,6 @@ public class PlayerAttackState : UnitState<PlayerController>
 		FDebug.Log($"{animEventEffect.effect.name}가 존재합니다.");
 		attackNode.effectPoolManager.DeactiveObject(animEventEffect.effect);
 		pc.attackCollider.radiusCollider.enabled = false;
-		pc.animator.SetBool(NormalAttackAnimKey, false);
 	}
 
 	public override void OnTriggerEnter(PlayerController unit, Collider other)


### PR DESCRIPTION
본 PR은 다음 수정 사항을 담고 있습니다.

- 콤보 공격 시 Idle로 넘어가던 현상 수정
- 불필요한 코드 삭제
- Animator 일부 개편

---

콤보 공격 및 돌진(차징) 공격 시 다음과 같은 문제가 있을 수 있습니다.
(본 PR 이전에 존재하던 문제 포함)

### 콤보공격
- 콤보 공격 시 Idle로 넘어가진 않지만 여전히 끊기는 듯하게 보일 수 있음.
    - 이는 후딜레이 스킵으로 애니메이션을 도중 스킵하게 되는데 이를 애니메이터로 보간하면서 부드럽게 전환되지 않아 생기는 문제로 추정됨. 이에 따라 이 부분은 좀 더 연구가 필요할 것으로 보임.

### 돌진(차징) 공격
- K를 누르면 K를 떼지 않고도 전진하는 현상
    - K Animation이 Legacy라 J와 Animation을 혼용하여 생기는 현상. 이는 구조적 문제도 존재하여 추후 수정 예정.