### PR TITLE
UnitBase 수정

### DIFF
--- a/Assets/Scripts/Objects/Unit/Status/OriginStatus.cs
+++ b/Assets/Scripts/Objects/Unit/Status/OriginStatus.cs
@@ -8,7 +8,7 @@ using UnityEngine;
 public class OriginStatus : ScriptableObject
 {
 	[SerializeField] private List<StatusData> status = new List<StatusData>();
-	
+
 	public void AutoGenerator()
 	{
 		if (status is not null)
@@ -17,7 +17,7 @@ public class OriginStatus : ScriptableObject
 		}
 
 		var statusTypeList = Enum.GetValues(typeof(StatusType)).Cast<StatusType>();
-		
+
 		foreach (var statusType in statusTypeList)
 		{
 			if (statusType is StatusType.NONE or StatusType.MAX)
@@ -32,5 +32,29 @@ public class OriginStatus : ScriptableObject
 	public List<StatusData> GetStatus()
 	{
 		return status;
+	}
+
+	public bool HasStatus(StatusType type)
+	{
+		var element = status.Find((x) => x.type == type);
+
+		if (element is null)
+		{
+			return false;
+		}
+
+		return true;
+	}
+
+	public StatusData GetElement(StatusType type)
+	{
+		if (HasStatus(type))
+		{
+			FDebug.Log("Status 데이터가 존재하지 않습니다.");
+			return null;
+		}
+
+		return status.Find((x) => x.type == type);
+
 	}
 }

--- a/Assets/Scripts/System/Buff/Each/BuffDot.cs
+++ b/Assets/Scripts/System/Buff/Each/BuffDot.cs
@@ -24,7 +24,7 @@ public class BuffDot : BuffBehaviour
 
 	public void DotHit()
 	{
-		var damage = BuffData.BuffStatus.GetStatusElement(StatusType.ATTACK_POINT).GetValue();
+		var damage = BuffData.BuffStatus.GetElement(StatusType.ATTACK_POINT).GetValue();
 		targetUnit.status.GetStatus(StatusType.CURRENT_HP).SubValue(damage);
 	}
 }

--- a/Assets/Scripts/System/Buff/Each/BuffShock.cs
+++ b/Assets/Scripts/System/Buff/Each/BuffShock.cs
@@ -10,7 +10,7 @@ public class BuffShock : BuffBehaviour
 	{
 		base.Active(unit);
 
-		var buffSpeed = BuffData.BuffStatus.GetStatusElement(StatusType.SPEED).GetValue();
+		var buffSpeed = BuffData.BuffStatus.GetElement(StatusType.SPEED).GetValue();
 
 		currSpeed = targetUnit.status.GetStatus(StatusType.SPEED).GetValue();
 		targetUnit.status.GetStatus(StatusType.SPEED).MultipleValue(buffSpeed);


### PR DESCRIPTION
UnitBase 수정
==========
### 문제점
- `Status`가 필요한 `Object`에 `Status`를 관리할 수 있는 스크립트가 `StatusManager`뿐이었음
   - 모든 `Object`에 동일한 `StatusManager`를 추가할 경우, 변경 필요가 없는 `Object`의 경우 비효율적임
----------
### 변경 사항
- `OriginStatus`에 개별의 `Element`에 접근 가능한 메서드를 추가함

----------